### PR TITLE
Parse origin url in order to remove the username from it.

### DIFF
--- a/src/GitExtensions.AzureDevOps/Services/GitUICommandsService.cs
+++ b/src/GitExtensions.AzureDevOps/Services/GitUICommandsService.cs
@@ -14,6 +14,10 @@ namespace GitExtensions.AzureDevOps.Services
             var configLines = File.ReadAllLines(_commands.Module.WorkingDirGitDir + "config");
             var urlLine = configLines.FirstOrDefault(x => x.Contains("url = "));
             var remoteUrl = urlLine.Split(splitCharacters).LastOrDefault()?.Trim();
+
+            // If username is present in the URL config, removing it in order to use default credentials
+            remoteUrl = System.Text.RegularExpressions.Regex.Replace(remoteUrl,@"(https?:\/\/)([^@\/]+@)","$1");
+
             return remoteUrl;
         }
     }


### PR DESCRIPTION
When origin url is formated as `https://username@dev.azure.com/MyCompagny/MyGroup/_git/myRepo`,
it removes the username@ from it before opening it into the default browser.

Issue: #2