### PR TITLE
Auto-detect the target branch.

### DIFF
--- a/src/GitExtensions.AzureDevOps/GitExtensions.AzureDevOps.csproj
+++ b/src/GitExtensions.AzureDevOps/GitExtensions.AzureDevOps.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <UseWindowsForms>true</UseWindowsForms>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GitExtensions.Extensibility" Version="0.3.*" />
-    <None Include="Docs\README.md" Pack="true" PackagePath="\"/>
+    <PackageReference Include="GitExtensions.Extensibility" Version="0.4.*" />
+    <None Include="Docs\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!-- Reference to GitExtensions dlls. -->

--- a/src/GitExtensions.AzureDevOps/GitExtensions.AzureDevOps.nuspec
+++ b/src/GitExtensions.AzureDevOps/GitExtensions.AzureDevOps.nuspec
@@ -9,7 +9,7 @@
     <iconUrl>$iconUrl$</iconUrl>
     <tags>$tags$</tags>
     <dependencies>
-      <dependency id="GitExtensions.Extensibility" version="[0.3.0, 0.4.0)" />
+		<dependency id="GitExtensions.Extensibility" version="[0.4.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/GitExtensions.AzureDevOps/UI/CreatePullRequestCommand.cs
+++ b/src/GitExtensions.AzureDevOps/UI/CreatePullRequestCommand.cs
@@ -1,12 +1,9 @@
 ﻿using GitExtensions.AzureDevOps.Services;
 using GitExtensions.Extensibility.Git;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Security.Policy;
-using System.Text;
+using System.Threading;
 using System.Web;
 using System.Windows.Input;
 
@@ -25,7 +22,38 @@ namespace GitExtensions.AzureDevOps.UI
         {
             string remoteUrl = GitUICommandsService.GetRemoteUrl(_commands);
             var branch = _commands.Module.GetSelectedBranch();
+            
+            // Create default URL
             var processUrl = $"{remoteUrl}/pullrequestcreate?sourceRef={HttpUtility.UrlEncode(branch.Trim())}";
+
+            // Get the target branch of the PR by finding the parent branch
+            var commitSha = _commands.Module.GetCurrentCheckout();
+            var parentCommits = _commands.Module.GetParentRevisions(commitSha);
+
+            if (parentCommits.Count > 0)
+            {
+                var remoteBranch = _commands.Module.GetRemoteBranch(branch);
+                var parentBranches = parentCommits
+                    .SelectMany(parent => _commands.Module.GetAllBranchesWhichContainGivenCommit(parent.ObjectId, getLocal: false, getRemote: true, CancellationToken.None))
+                    .Distinct(StringComparer.OrdinalIgnoreCase);
+				if (parentBranches != null)
+				{
+					var originTargetBranch = parentBranches.FirstOrDefault(b => b.EndsWith("/develop", StringComparison.OrdinalIgnoreCase))
+							   ?? parentBranches.FirstOrDefault(b => b.EndsWith("/master", StringComparison.OrdinalIgnoreCase))
+							   ?? parentBranches.FirstOrDefault(b => !b.Contains(branch, StringComparison.OrdinalIgnoreCase))
+							   ?? parentBranches.FirstOrDefault(b => !b.Contains(remoteBranch, StringComparison.OrdinalIgnoreCase))
+							   ?? parentBranches.FirstOrDefault("");
+					var remoteNames = _commands.Module.GetRemoteNames();
+					var temp = remoteNames.Select(r => r + "/");
+               var targetBranch = temp.Aggregate(originTargetBranch, (current, prefix) =>
+																current.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+																	? current.Substring(prefix.Length)
+																	: current);
+					if (!string.IsNullOrWhiteSpace(targetBranch))
+						processUrl += $"&targetRef={HttpUtility.UrlEncode(targetBranch.Trim())}";
+				}
+            }
+
             Process myProcess = new Process();
             myProcess.StartInfo.UseShellExecute = true;
             myProcess.StartInfo.FileName = processUrl;

--- a/src/GitExtensions.AzureDevOps/UI/ViewListOfPullRequestsCommand.cs
+++ b/src/GitExtensions.AzureDevOps/UI/ViewListOfPullRequestsCommand.cs
@@ -1,13 +1,7 @@
 ﻿using GitExtensions.AzureDevOps.Services;
 using GitExtensions.Extensibility.Git;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Web;
 using System.Windows.Input;
 
 namespace GitExtensions.AzureDevOps.UI


### PR DESCRIPTION
 - Find previous parent branch on origin or local
 - If not found fallback on Develop or Master
 - Remove useless libraries from the scripts.
 - Update mandatory GitExtensions.Extensibility library

Issue: #1